### PR TITLE
Restore allow_writeable_chroot option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.1
   - 2.3.1
 
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
     - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"
@@ -39,16 +38,14 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
+    - rvm: 2.1.1
       env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
+    - rvm: 2.1.1
       env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
+    - rvm: 2.1.1
       env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.0.0"
     - rvm: 1.8.7
@@ -70,6 +67,8 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.9.0"
     - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 4.9.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 4.9.0"
@@ -85,8 +84,6 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.2.0"
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" travis_retry bundle exec rake validate lint spec'
 
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,14 @@ gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
 gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
 gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
 gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
-gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'
-
+gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint'             if RUBY_VERSION >= '2.0.0'
+gem 'semantic_puppet'                if RUBY_VERSION < '4.0.0'
+gem 'public_suffix', '<= 1.3.3' if RUBY_VERSION < '2.0.0'
+gem 'gettext-setup',   :require => false
 
 # Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7
-gem 'puppetlabs_spec_helper',    '2.0.2', :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
+gem 'puppetlabs_spec_helper',    '1.2.2', :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'puppetlabs_spec_helper', '>= 2.0.2', :require => false if RUBY_VERSION >= '1.9'
 gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,8 +129,8 @@ class vsftpd (
   $hide_file                 =  undef,
   $banner_file               =  undef,
   $cmds_allowed              =  undef,
-  $allow_writeable_chroot    =  undef,
   $anon_root                 =  undef,
+  $allow_writeable_chroot    =  undef,
   $deny_file                 =  undef,
   $dsa_cert_file             =  undef,
   $dsa_private_key_file      =  undef,
@@ -188,9 +188,6 @@ class vsftpd (
   }
   if $banner_file != undef {
     validate_string($banner_file)
-  }
-  if $allow_writeable_chroot != undef {
-    validate_string($allow_writeable_chroot)
   }
   if $anon_root != undef {
     validate_string($anon_root)
@@ -323,6 +320,11 @@ class vsftpd (
 
   validate_re($chroot_list_enable, '^(YES|NO)$',
     "vsftpd::chroot_list_enable is <${chroot_list_enable}>. Must be either 'YES' or 'NO'.")
+
+  if $allow_writeable_chroot != undef {
+    validate_re($allow_writeable_chroot, '^(YES|NO)$',
+      "vsftpd::allow_writeable_chroot is <${allow_writeable_chroot}>. Must be either 'YES' or 'NO'.")
+  }
 
   validate_re($ls_recurse_enable, '^(YES|NO)$',
     "vsftpd::ls_recurse_enable is <${ls_recurse_enable}>. Must be either 'YES' or 'NO'.")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -260,6 +260,14 @@ describe 'vsftpd' do
       it { should contain_file(fName).with_content(/^force_local_logins_ssl=YES$/) }
       it { should contain_file(fName).with_content(/^ssl_ciphers=DES-CBC3-SHA$/) }
     end
+    context "defaults with allow_writeable_chroot set to YES" do
+      let :params do
+        {
+          :"allow_writeable_chroot" => 'YES'
+        }
+      end
+      it { should contain_file(fName).with_content(/^allow_writeable_chroot=YES$/) }
+    end
   end
   describe 'variable type and content validations' do
     # set needed custom facts and variables
@@ -272,7 +280,7 @@ describe 'vsftpd' do
 
     validations = {
       'string' => {
-        :name    => ['guest_username', 'pam_service_name', 'ftp_username', 'chown_username', 'nopriv_user', 'message_file', 'ssl_ciphers', 'xferlog_file', 'vsftpd_log_file', 'userlist_file', 'chroot_list_file', 'banned_email_file', 'email_password_file', 'rsa_cert_file', 'ftpd_banner', 'hide_file', 'banner_file', 'allow_writeable_chroot', 'anon_root', 'cmds_allowed', 'deny_file', 'dsa_cert_file', 'dsa_private_key_file', 'listen_address', 'listen_address6', 'local_root', 'pasv_address', 'rsa_private_key_file', 'user_config_dir', 'user_sub_token'],
+        :name    => ['guest_username', 'pam_service_name', 'ftp_username', 'chown_username', 'nopriv_user', 'message_file', 'ssl_ciphers', 'xferlog_file', 'vsftpd_log_file', 'userlist_file', 'chroot_list_file', 'banned_email_file', 'email_password_file', 'rsa_cert_file', 'ftpd_banner', 'hide_file', 'banner_file', 'anon_root', 'cmds_allowed', 'deny_file', 'dsa_cert_file', 'dsa_private_key_file', 'listen_address', 'listen_address6', 'local_root', 'pasv_address', 'rsa_private_key_file', 'user_config_dir', 'user_sub_token'],
         :valid   => ['string_word'],
         :invalid => [['array'],a={'ha'=>'sh'},true,false],
         :message => 'is not a string',
@@ -296,7 +304,7 @@ describe 'vsftpd' do
         :message => '(Expected first argument to be an Integer or Array|Expected [-]?\d+ to be (smaller|greater) or equal to (0|65535))',
       },
       'string_yes_no' => {
-        :name    => ['anonymous_enable', 'local_enable', 'write_enable', 'anon_upload_enable', 'anon_mkdir_write_enable', 'dirmessage_enable', 'xferlog_enable', 'connect_from_port_20', 'chown_uploads', 'xferlog_std_format', 'async_abor_enable', 'ascii_upload_enable', 'ascii_download_enable', 'chroot_local_user', 'chroot_list_enable', 'ls_recurse_enable', 'listen', 'userlist_enable', 'userlist_deny', 'tcp_wrappers', 'hide_ids', 'setproctitle_enable', 'text_userdb_names', 'ssl_request_cert', 'anon_other_write_enable', 'anon_world_readable_only', 'background', 'check_shell', 'chmod_enable', 'deny_email_enable', 'dirlist_enable', 'download_enable', 'dual_log_enable', 'force_dot_files', 'force_anon_data_ssl', 'force_anon_logins_ssl', 'force_local_data_ssl', 'force_local_logins_ssl', 'guest_enable', 'listen_ipv6', 'lock_upload_files', 'log_ftp_protocol', 'mdtm_write', 'no_anon_password', 'no_log_lock', 'one_process_model', 'passwd_chroot_enable', 'pasv_addr_resolve', 'pasv_enable', 'pasv_promiscuous', 'port_enable', 'port_promiscuous', 'reverse_lookup_enable', 'run_as_launching_user', 'secure_email_list_enable', 'session_support', 'ssl_enable', 'ssl_sslv2', 'ssl_sslv3', 'ssl_tlsv1', 'syslog_enable', 'tilde_user_enable', 'use_localtime', 'use_sendfile', 'virtual_use_local_privs'],
+        :name    => ['allow_writeable_chroot', 'anonymous_enable', 'local_enable', 'write_enable', 'anon_upload_enable', 'anon_mkdir_write_enable', 'dirmessage_enable', 'xferlog_enable', 'connect_from_port_20', 'chown_uploads', 'xferlog_std_format', 'async_abor_enable', 'ascii_upload_enable', 'ascii_download_enable', 'chroot_local_user', 'chroot_list_enable', 'ls_recurse_enable', 'listen', 'userlist_enable', 'userlist_deny', 'tcp_wrappers', 'hide_ids', 'setproctitle_enable', 'text_userdb_names', 'ssl_request_cert', 'anon_other_write_enable', 'anon_world_readable_only', 'background', 'check_shell', 'chmod_enable', 'deny_email_enable', 'dirlist_enable', 'download_enable', 'dual_log_enable', 'force_dot_files', 'force_anon_data_ssl', 'force_anon_logins_ssl', 'force_local_data_ssl', 'force_local_logins_ssl', 'guest_enable', 'listen_ipv6', 'lock_upload_files', 'log_ftp_protocol', 'mdtm_write', 'no_anon_password', 'no_log_lock', 'one_process_model', 'passwd_chroot_enable', 'pasv_addr_resolve', 'pasv_enable', 'pasv_promiscuous', 'port_enable', 'port_promiscuous', 'reverse_lookup_enable', 'run_as_launching_user', 'secure_email_list_enable', 'session_support', 'ssl_enable', 'ssl_sslv2', 'ssl_sslv3', 'ssl_tlsv1', 'syslog_enable', 'tilde_user_enable', 'use_localtime', 'use_sendfile', 'virtual_use_local_privs'],
         :valid   => ['YES', 'NO'],
         :invalid => [['array'],a={'ha'=>'sh'},true,false],
         :message => 'Must be either \'YES\' or \'NO\'',

--- a/spec/fixtures/vsftpd_with_default_params_apt_based
+++ b/spec/fixtures/vsftpd_with_default_params_apt_based
@@ -148,6 +148,11 @@ use_sendfile=YES
 chroot_local_user=NO
 chroot_list_enable=NO
 
+# If you want the chroot environment to be writable you will need to set 
+# allow_writeable_chroot=YES. Otherwise vsftpd because of default security
+# settings will complain if it detects that chroot is writable.
+# allow_writeable_chroot=NO
+
 ssl_enable=NO
 
 # You may activate the "-R" option to the builtin ls. This is disabled by

--- a/spec/fixtures/vsftpd_with_default_params_rpm_based
+++ b/spec/fixtures/vsftpd_with_default_params_rpm_based
@@ -148,6 +148,11 @@ use_sendfile=YES
 chroot_local_user=NO
 chroot_list_enable=NO
 
+# If you want the chroot environment to be writable you will need to set 
+# allow_writeable_chroot=YES. Otherwise vsftpd because of default security
+# settings will complain if it detects that chroot is writable.
+# allow_writeable_chroot=NO
+
 ssl_enable=NO
 
 # You may activate the "-R" option to the builtin ls. This is disabled by

--- a/spec/fixtures/vsftpd_without_default_params_apt_based
+++ b/spec/fixtures/vsftpd_without_default_params_apt_based
@@ -153,6 +153,11 @@ use_sendfile=YES
 chroot_local_user=NO
 chroot_list_enable=NO
 
+# If you want the chroot environment to be writable you will need to set 
+# allow_writeable_chroot=YES. Otherwise vsftpd because of default security
+# settings will complain if it detects that chroot is writable.
+# allow_writeable_chroot=NO
+
 ssl_enable=NO
 
 # You may activate the "-R" option to the builtin ls. This is disabled by

--- a/spec/fixtures/vsftpd_without_default_params_rpm_based
+++ b/spec/fixtures/vsftpd_without_default_params_rpm_based
@@ -153,6 +153,11 @@ use_sendfile=YES
 chroot_local_user=NO
 chroot_list_enable=NO
 
+# If you want the chroot environment to be writable you will need to set 
+# allow_writeable_chroot=YES. Otherwise vsftpd because of default security
+# settings will complain if it detects that chroot is writable.
+# allow_writeable_chroot=NO
+
 ssl_enable=NO
 
 # You may activate the "-R" option to the builtin ls. This is disabled by

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -196,6 +196,15 @@ chroot_list_enable=<%= @chroot_list_enable %>
 chroot_list_file=<%= @chroot_list_file %>
 <% end -%>
 
+# If you want the chroot environment to be writable you will need to set 
+# allow_writeable_chroot=YES. Otherwise vsftpd because of default security
+# settings will complain if it detects that chroot is writable.
+<% if @allow_writeable_chroot -%>
+allow_writeable_chroot=<%= @allow_writeable_chroot %>
+<% else -%>
+# allow_writeable_chroot=NO
+<% end -%>
+
 ssl_enable=<%= @ssl_enable %>
 <% if @ssl_enable == 'YES' -%>
 # This option specifies the location of the RSA certificate to use for SSL encrypted connections.


### PR DESCRIPTION
For some reason allow_writeable_chroot were removed in commit 0068efd. This patch adds it back to the template.