### PR TITLE
Fixed bug in vsftpd.conf template

### DIFF
--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -63,7 +63,7 @@ no_anon_password=<%= @no_anon_password %>
 <% end -%>
 <% if @anon_root -%>
 
-  # This option represents a directory which vsftpd will try to change into after
+# This option represents a directory which vsftpd will try to change into after
 # an anonymous login. Failure is silently ignored.
 # Default: (None)
 anon_root=<%= @anon_root %>


### PR DESCRIPTION
In the template for vsftpd.conf some whitespaces preceded one of
the comments. This causes some versions of vsftpd not to start.