### PR TITLE
Remove whitespaces from vsftpd.conf template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rspec-puppet', '~> 2.5.0'
 gem 'json',                   '<= 1.8'   if RUBY_VERSION < '2.0.0'
 gem 'json_pure',              '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.1'
+gem 'metadata-json-lint',     '1.1.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.1'
 gem 'metadata-json-lint'                 if RUBY_VERSION >= '2.1'
 gem 'parallel_tests',         '<= 2.9.0' if RUBY_VERSION > '1.9.3' # [1]
 gem 'puppetlabs_spec_helper', '2.0.2'    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9' # [1]

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem 'rspec-puppet', '~> 2.5.0'
 gem 'json',                   '<= 1.8'   if RUBY_VERSION < '2.0.0'
 gem 'json_pure',              '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0'
-gem 'metadata-json-lint'                 if RUBY_VERSION >= '2.0'
+gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.1'
+gem 'metadata-json-lint'                 if RUBY_VERSION >= '2.1'
 gem 'parallel_tests',         '<= 2.9.0' if RUBY_VERSION > '1.9.3' # [1]
 gem 'puppetlabs_spec_helper', '2.0.2'    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9' # [1]
 gem 'puppetlabs_spec_helper', '>= 2.0.0' if RUBY_VERSION >= '1.9' # [1]

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -63,7 +63,7 @@ no_anon_password=<%= @no_anon_password %>
 <% end -%>
 <% if @anon_root -%>
 
-  # This option represents a directory which vsftpd will try to change into after
+# This option represents a directory which vsftpd will try to change into after
 # an anonymous login. Failure is silently ignored.
 # Default: (None)
 anon_root=<%= @anon_root %>


### PR DESCRIPTION
Some versions of vsftpd will fail on startup if they are present.
eg: vsftpd-3.0.2-10.el7.x86_64 on RHEL 7.2